### PR TITLE
IA-34-Implement-QR-Code-Generation-Endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 // email
     implementation 'jakarta.mail:jakarta.mail-api:2.1.3'
     implementation 'org.eclipse.angus:jakarta.mail:2.0.0'
+//QR code generation
+    implementation 'com.google.zxing:core:3.5.4'
+    implementation 'com.google.zxing:javase:3.5.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/rocs/infirmary/application/controller/student/StudentController.java
+++ b/src/main/java/com/rocs/infirmary/application/controller/student/StudentController.java
@@ -45,10 +45,19 @@ public class StudentController {
         this.studentHealthProfileService = studentHealthProfileService;
         this.qrCodeProviderService = qrCodeProviderService;
     }
+    /**
+     * This converter allows Spring to automatically serialize {@code BufferedImage} responses to HTTP responses in image format.
+     * @return a {@link BufferedImageHttpMessageConverter} for handling image responses
+     */
     @Bean
     public HttpMessageConverter<BufferedImage> createImageHttpMessageConverter() {
         return new BufferedImageHttpMessageConverter();
     }
+    /**
+     * this is used to facilitate request for updating student health profile
+     *
+     * @return ResponseEntity containing the Student clinic visit history, and the Http Status
+     * */
     @PutMapping("/health-profile/update")
     public ResponseEntity<Student> updateStudent(@RequestBody StudentHealthInformation student) throws StudentNotFoundException, SectionNotFoundException {
         return new ResponseEntity<>(this.studentService.updateStudentHealthInformation(student),HttpStatus.OK);

--- a/src/main/java/com/rocs/infirmary/application/service/qr/code/QrCodeProviderService.java
+++ b/src/main/java/com/rocs/infirmary/application/service/qr/code/QrCodeProviderService.java
@@ -1,0 +1,20 @@
+package com.rocs.infirmary.application.service.qr.code;
+
+import com.rocs.infirmary.application.exception.domain.StudentNotFoundException;
+import org.springframework.security.core.Authentication;
+
+import java.awt.image.BufferedImage;
+/**
+ * {@code QrCodeProviderService} is an Interface of QrCodeProviderServiceImpl
+ * */
+public interface QrCodeProviderService {
+    /**
+     * Generates a QR code image for the authenticated student.
+     * The QR code encodes a URL containing a secure and time limited parent JWT token that allows
+     * parents to view the student's health profile without requiring login.
+     *
+     * @param authentication the authentication object of the currently logged-in student
+     * @return a {@code BufferedImage} representing the QR code
+     */
+    BufferedImage generateQrCode(Authentication authentication) throws StudentNotFoundException;
+}

--- a/src/main/java/com/rocs/infirmary/application/service/qr/code/impl/QrCodeProviderServiceImpl.java
+++ b/src/main/java/com/rocs/infirmary/application/service/qr/code/impl/QrCodeProviderServiceImpl.java
@@ -1,0 +1,76 @@
+package com.rocs.infirmary.application.service.qr.code.impl;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.MultiFormatWriter;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+import com.rocs.infirmary.application.domain.student.Student;
+import com.rocs.infirmary.application.domain.user.User;
+import com.rocs.infirmary.application.exception.domain.StudentNotFoundException;
+import com.rocs.infirmary.application.exception.domain.UserNotFoundException;
+import com.rocs.infirmary.application.repository.student.StudentRepository;
+import com.rocs.infirmary.application.repository.user.UserRepository;
+import com.rocs.infirmary.application.service.qr.code.QrCodeProviderService;
+import com.rocs.infirmary.application.utils.security.jwt.token.provider.JwtTokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.awt.image.BufferedImage;
+/**
+ * Service implementation responsible for generating QR codes that allow parents to view a student's health profile.
+ * */
+@Service
+public class QrCodeProviderServiceImpl implements QrCodeProviderService {
+    @Value("${spring.application.base-url}")
+    private String baseUrl;
+    @Value("${spring.application.endpoints.parent-endpoint}")
+    private String parentEndpoint;
+
+    private final UserRepository userRepository;
+    private final StudentRepository studentRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    public QrCodeProviderServiceImpl(UserRepository userRepository, StudentRepository studentRepository, JwtTokenProvider jwtTokenProvider) {
+        this.userRepository = userRepository;
+        this.studentRepository = studentRepository;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public BufferedImage generateQrCode(Authentication authentication) throws StudentNotFoundException {
+        authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication instanceof AnonymousAuthenticationToken){
+            throw new UserNotFoundException("Unauthenticated user");
+        }
+
+        User user = this.userRepository.findUserByUsername(authentication.getName());
+        if(user == null) {
+            throw new UserNotFoundException("User not found");
+        }
+
+        Student student = this.studentRepository.findStudentByUserId(user.getId());
+        if(student == null){
+            throw new StudentNotFoundException("Student not found");
+        }
+
+        String parentToken = this.jwtTokenProvider.generateParentJwtToken(student.getLrn());
+
+        String url = baseUrl+parentEndpoint+parentToken;
+
+        int width = 300;
+        int height = 300;
+        QRCodeWriter barcodeWriter = new QRCodeWriter();
+        try {
+            BitMatrix matrix = barcodeWriter.encode(url,BarcodeFormat.QR_CODE,width,height);
+            return MatrixToImageWriter.toBufferedImage(matrix);
+        } catch (WriterException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/rocs/infirmary/application/service/qr/code/impl/QrCodeProviderServiceImpl.java
+++ b/src/main/java/com/rocs/infirmary/application/service/qr/code/impl/QrCodeProviderServiceImpl.java
@@ -35,6 +35,13 @@ public class QrCodeProviderServiceImpl implements QrCodeProviderService {
     private final UserRepository userRepository;
     private final StudentRepository studentRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    /**
+     * This creates a constructor for {@codde QrCodeProviderServiceImpl}
+     *
+     * @param userRepository represents the user repository
+     * @param studentRepository represents the student repository
+     * @param jwtTokenProvider the service used to provide jwt token
+     * */
     @Autowired
     public QrCodeProviderServiceImpl(UserRepository userRepository, StudentRepository studentRepository, JwtTokenProvider jwtTokenProvider) {
         this.userRepository = userRepository;

--- a/src/main/java/com/rocs/infirmary/application/utils/security/constants/SecurityConstant.java
+++ b/src/main/java/com/rocs/infirmary/application/utils/security/constants/SecurityConstant.java
@@ -8,6 +8,10 @@ public class SecurityConstant {
      */
     public static final long EXPIRATION_TIME = 432000000;
     /**
+     * parent token expiration time in milliseconds
+     */
+    public static final long PARENT_TOKEN_EXPIRATION_TIME = 86400000;
+    /**
      * token prefix bearer in Http headers
      * */
     public static final String TOKEN_PREFIX = "Bearer ";
@@ -27,6 +31,10 @@ public class SecurityConstant {
      * application description
      * */
     public static final String ROCS_ADMINISTRATION = "Infirmary Application self Service";
+    /**
+     * description for parent access
+     * */
+    public static final String PARENT_ACCESS = "Parent public access";
     /**
      * key for storing authorities in JWT claims
      * */

--- a/src/main/java/com/rocs/infirmary/application/utils/security/jwt/token/provider/JwtTokenProvider.java
+++ b/src/main/java/com/rocs/infirmary/application/utils/security/jwt/token/provider/JwtTokenProvider.java
@@ -43,6 +43,18 @@ public class JwtTokenProvider {
                 .sign(Algorithm.HMAC512(secret.getBytes()));
     }
     /**
+     * Generates JWT Token for Parent access
+     * The token will contain the student's LRN as the subject
+     * @param lrn of the student for whom the parent token is being generated
+     * @return the jwt token
+     * */
+    public String generateParentJwtToken(Long lrn){
+        return JWT.create().withIssuer(ROCS).withAudience(PARENT_ACCESS)
+                .withIssuedAt(new Date()).withSubject(lrn.toString())
+                .withExpiresAt(new Date(System.currentTimeMillis()+PARENT_TOKEN_EXPIRATION_TIME))
+                .sign(Algorithm.HMAC512(secret.getBytes()));
+    }
+    /**
      * Get authorities from the token.
      * @param token the jwt token
      * @return the list of authorities from the token

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -4,6 +4,7 @@ spring:
     base-url : "http://localhost:8080"
     endpoints:
       reset-password: "/user/reset-password?token="
+      parent-endpoint: "/parent/view/student-profile?token="
   datasource:
     url: jdbc:oracle:thin:@localhost:1521:orcl
     username: infirmary


### PR DESCRIPTION
In this PR, I implemented a service for generating QR codes to view a student's health profile. This QR code will be used by the student's parent to access the student's health profile without needing to log in

Sample output

<img width="1280" height="1024" alt="image" src="https://github.com/user-attachments/assets/faa2dc67-c2ed-4995-bc4d-d1f5868f6b2b" />

<img width="1122" height="502" alt="image" src="https://github.com/user-attachments/assets/4766a14a-d49b-4529-a2c7-62206e0abec7" />

the qr contains the endpoint and the parent token. 

<img width="1266" height="596" alt="image" src="https://github.com/user-attachments/assets/4cb16c15-efeb-4b48-8746-712b38018139" />

I used the student's LRN as the JWT subject so that we can extract the LRN directly from the token itself.

NOTE: the endpoint for retrieving the student health profile is not yet implemented 

